### PR TITLE
Adjusted for working with URL rewrite

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -11,7 +11,7 @@ return array(
 	'default-api-version' => null,
 	'default-swagger-version' => null,
 	'api-doc-template' => null,
-	'suffix' => '.{format}',
+//	'suffix' => '.{format}',
 
 	'title' => 'Swagger UI'
 );

--- a/src/controllers/SwaggerController.php
+++ b/src/controllers/SwaggerController.php
@@ -32,8 +32,9 @@ class SwaggerController extends Controller
         return view('latrell/swagger::index');
     }
 
-    public function getDocs($page = 'api-docs.json')
+    public function getDocs($page = 'api-docs')
     {
+        $page = $page . '.json';
         $path = head((array) config('latrell-swagger.output')) . DIRECTORY_SEPARATOR . $page;
         if (! file_exists($path)) {
             App::abort(404);

--- a/src/controllers/SwaggerController.php
+++ b/src/controllers/SwaggerController.php
@@ -17,7 +17,7 @@ class SwaggerController extends Controller
         $swagger->paths = config('latrell-swagger.paths');
         $swagger->exclude = config('latrell-swagger.exclude');
         $swagger->output = config('latrell-swagger.output');
-        $swagger->suffix = config('latrell-swagger.suffix');
+        $swagger->suffix = "";
         $swagger->default_api_version = config('latrell-swagger.default-api-version');
         $swagger->default_swagger_version = config('latrell-swagger.default-swagger-version');
         $swagger->api_doc_template = config('latrell-swagger.api-doc-template');


### PR DESCRIPTION
When using full file name as request param (like user.json) it does't work with URL rewriting. Of course you could write URL-s with index.php but that isn't so pretty and usually is confusing. Also I don't quite get purpose of suffix option in configuration. You hard coded resource files in .json so  suffix only modifies request param name and causes error 404. It is best to leave suffix blank and remove it from conf file. I might be using this wrong but would like to hear your response.
